### PR TITLE
Feature/update publications data2

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -29,7 +29,7 @@
   school = {Massachusetts Institute of Technology},
   year = {2015},
   url = {https://dspace.mit.edu/handle/1721.1/97259},
-  html = {https://dspace.mit.edu/handle/1721.1/97259}
+  html = {https://dspace.mit.edu/handle/1721.1/97259},
   eprint = {https://dspace.mit.edu/bitstream/handle/1721.1/97259/910513648-MIT.pdf},
 }
 
@@ -127,7 +127,7 @@
   issn = {0037-1106},
   doi = {10.1785/0120070124},
   url = {https://doi.org/10.1785/0120070124},
-  html = {https://pubs.geoscienceworld.org/ssa/bssa/article-abstract/98/3/1412/341950/Induced-Dynamic-Nonlinear-Ground-Response-at}
+  html = {https://pubs.geoscienceworld.org/ssa/bssa/article-abstract/98/3/1412/341950/Induced-Dynamic-Nonlinear-Ground-Response-at},
   eprint = {https://pubs.geoscienceworld.org/ssa/bssa/article-pdf/98/3/1412/3673976/1412.pdf},
 }
 
@@ -140,6 +140,6 @@
   school = {Massachusetts Institute of Technology},
   year = {2003},
   url = {http://hdl.handle.net/1721.1/30127},
-  html = {http://hdl.handle.net/1721.1/30127}
+  html = {http://hdl.handle.net/1721.1/30127},
   eprint = {https://dspace.mit.edu/bitstream/handle/1721.1/30127/55873860-MIT.pdf},
 }

--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -29,6 +29,7 @@
   school = {Massachusetts Institute of Technology},
   year = {2015},
   url = {https://dspace.mit.edu/handle/1721.1/97259},
+  html = {https://dspace.mit.edu/handle/1721.1/97259}
   eprint = {https://dspace.mit.edu/bitstream/handle/1721.1/97259/910513648-MIT.pdf},
 }
 
@@ -44,7 +45,7 @@
   doi = {https://doi.org/10.1002/2014GC005320},
   url = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1002/2014GC005320},
   eprint = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1002/2014GC005320},
-  abstract = {Abstract Subduction of the Cocos plate beneath southern Mexico is characterized by several unusual features, such as a discontinuous volcanic arc, unusual arc chemistry, and anomalously low topography of Tehuantepec Isthmus. Recent seismic images from both receiver functions and seismic tomography suggest that there may be an additional, opposing structure dipping to the southwest from the Gulf of Mexico, and these images have been previously explained by a southwest-dipping slab. However, standard models of the Caribbean tectonic history do not support this interpretation. To better define the Cocos slab's structure and the possible existence of a structure dipping in the opposite direction, dense seismic data across southern Mexico are used to form high-resolution seismic images, based on the 2-D generalized radon transform method, and to relocate regional earthquakes. Our images show the Cocos plate dipping at 30° to the northeast encounters the anomaly that is dipping in the opposite sense at ∼150 km depth. Relocated seismicity clearly delineates a Wadati-Benioff zone that marks the subducting Cocos plate. A cluster of seismicity also appears at ∼150 km depth which may be related to the subduction of the Tehuantepec ridge and/or to the imaged seismic structure with opposite polarity.},
+  abstract = {Subduction of the Cocos plate beneath southern Mexico is characterized by several unusual features, such as a discontinuous volcanic arc, unusual arc chemistry, and anomalously low topography of Tehuantepec Isthmus. Recent seismic images from both receiver functions and seismic tomography suggest that there may be an additional, opposing structure dipping to the southwest from the Gulf of Mexico, and these images have been previously explained by a southwest-dipping slab. However, standard models of the Caribbean tectonic history do not support this interpretation. To better define the Cocos slab's structure and the possible existence of a structure dipping in the opposite direction, dense seismic data across southern Mexico are used to form high-resolution seismic images, based on the 2-D generalized radon transform method, and to relocate regional earthquakes. Our images show the Cocos plate dipping at 30° to the northeast encounters the anomaly that is dipping in the opposite sense at ∼150 km depth. Relocated seismicity clearly delineates a Wadati-Benioff zone that marks the subducting Cocos plate. A cluster of seismicity also appears at ∼150 km depth which may be related to the subduction of the Tehuantepec ridge and/or to the imaged seismic structure with opposite polarity.},
   year = {2014}
 }
 
@@ -126,6 +127,7 @@
   issn = {0037-1106},
   doi = {10.1785/0120070124},
   url = {https://doi.org/10.1785/0120070124},
+  html = {https://pubs.geoscienceworld.org/ssa/bssa/article-abstract/98/3/1412/341950/Induced-Dynamic-Nonlinear-Ground-Response-at}
   eprint = {https://pubs.geoscienceworld.org/ssa/bssa/article-pdf/98/3/1412/3673976/1412.pdf},
 }
 
@@ -137,6 +139,7 @@
   numpages = {37},
   school = {Massachusetts Institute of Technology},
   year = {2003},
-  url = {https://dspace.mit.edu/handle/1721.1/68615},
-  eprint = {https://dspace.mit.edu/bitstream/handle/1721.1/68615/PEARCE.pdf},
+  url = {http://hdl.handle.net/1721.1/30127},
+  html = {http://hdl.handle.net/1721.1/30127}
+  eprint = {https://dspace.mit.edu/bitstream/handle/1721.1/30127/55873860-MIT.pdf},
 }

--- a/_config.yml
+++ b/_config.yml
@@ -318,7 +318,7 @@ filtered_bibtex_keywords:
   ]
 
 # Maximum number of authors to be shown for each publication (more authors are visible on click)
-max_author_limit: 3 # leave blank to always show all authors
+max_author_limit: 4 # leave blank to always show all authors
 more_authors_animation_delay: 10 # more authors are revealed on click using animation; smaller delay means faster animation
 
 # Enables publication thumbnails. If disabled, none of the publications will display thumbnails, even if specified in the bib entry.


### PR DESCRIPTION
This PR contains a second round of updates to the publications tab, with the following changes:
- update jekyll scholar section in `_config.yml` so that at least 4 authors are shown for each publication entry (i.e. `max_author_limit=4`)
- fix erroneous inclusion of the word Abstract in the abstract section of Kim et al.
- add html tags to both my theses, and to Lawrence et al, so that links are provided to the websites of each publication