### PR TITLE
Backdate Part 2 to 2026-06-04 to surface it on the blog index

### DIFF
--- a/_posts/2026-06-04-reading-a-claude-code-session-line-by-line.md
+++ b/_posts/2026-06-04-reading-a-claude-code-session-line-by-line.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Reading a Claude Code session, line by line"
-date: 2026-06-05 12:00:00-0800
+date: 2026-06-04 12:00:00-0800
 description: "Part 2 of the anatomy series. Every type of line in a session JSONL, the snake_case/camelCase split that reveals two layers (API content wrapped in Claude Code's bookkeeping), and why tool results live inside user messages."
 categories: ["foundation"]
 tags: ["claude-code", "agent-sdk", "jsonl", "sessions"]


### PR DESCRIPTION
Fixes Part 2 disappearing from the blog index after merge.

## Problem

Part 2 was merged in [PR #17](https://github.com/frederick-douglas-pearce/frederick-douglas-pearce.github.io/pull/17) with a `date:` of `2026-06-05 12:00:00-0800` (a placeholder picked at draft time). Today is 2026-06-04. Jekyll's default behavior (`future: false`, unset in `_config.yml`) silently skips future-dated posts from the build — the file was deployed but didn't appear on the blog index.

## Fix

Renames `_posts/2026-06-05-...md` → `_posts/2026-06-04-...md` and updates the frontmatter `date:` field to match. No content changes.

## Verification

- `npx prettier _posts/2026-06-04-... --check` — passes locally before push.
- Matches the upstream change in [claude-code-sessions@09ce344](https://github.com/frederick-douglas-pearce/claude-code-sessions/commit/09ce344) where the source post was renamed the same way.

## Notes

If you want to prevent this class of issue going forward, the alternative fix is adding `future: true` to `_config.yml` (one-line change). Not doing that here because backdating is what you asked for and keeps the safety net for future drafts.
