### PR TITLE
Fix Part 2 time to midnight Pacific so it's past at build time

### DIFF
--- a/_posts/2026-06-04-reading-a-claude-code-session-line-by-line.md
+++ b/_posts/2026-06-04-reading-a-claude-code-session-line-by-line.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Reading a Claude Code session, line by line"
-date: 2026-06-04 12:00:00-0800
+date: 2026-06-04 00:00:00-0800
 description: "Part 2 of the anatomy series. Every type of line in a session JSONL, the snake_case/camelCase split that reveals two layers (API content wrapped in Claude Code's bookkeeping), and why tool results live inside user messages."
 categories: ["foundation"]
 tags: ["claude-code", "agent-sdk", "jsonl", "sessions"]


### PR DESCRIPTION
Follow-up to [PR #18](https://github.com/frederick-douglas-pearce/frederick-douglas-pearce.github.io/pull/18).

## Problem

PR #18 backdated Part 2 from 2026-06-05 to 2026-06-04, but the `date:` carried the default time of `12:00:00-0800` (12 PM Pacific = 20:00 UTC) appended by `tooling/publish-to-pages.py` upstream. Current UTC is ~08:54 — so the post was still ~11 hours in the future and Jekyll's `future: false` default kept skipping it from the blog index.

## Fix

Changes time from `12:00:00-0800` → `00:00:00-0800` (= 08:00 UTC, ~54 minutes in the past as of this PR). Post is now past-dated under any reasonable interpretation and will surface on the next deploy.

## Follow-up

The script default of noon is the root cause. Filing an upstream issue to change `tooling/publish-to-pages.py`'s `DEFAULT_TIME_SUFFIX` to `00:00:00-0800` so this doesn't bite again. Once the script is fixed, future posts won't need this manual correction.
