### PR TITLE
Fix Dependabot security alerts: bump nokogiri, addressable, css_parser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'jekyll'
 
 # Security updates - minimum versions to address vulnerabilities
-gem 'nokogiri', '>= 1.19.1'    # CVE patches for libxml2
+gem 'nokogiri', '>= 1.19.3'    # CVE patches for libxml2; >=1.19.3 fixes ReDoS + XSLT leak (GHSA-c4rq-3m3g-8wgx, GHSA-v2fc-qm4h-8hqv)
 gem 'rexml', '>= 3.4.2'        # DoS vulnerability fix
 gem 'uri', '>= 1.0.4'          # Credential leakage fix
 gem 'activesupport', '>= 8.0.4.1' # DoS, XSS, and ReDoS fixes
@@ -33,7 +33,7 @@ end
 
 # Gems for development or external data fetching (outside :jekyll_plugins)
 group :other_plugins do
-    gem 'css_parser'
+    gem 'css_parser', '~> 1.22'  # >=1.22.0 fixes HTTPS MITM cert validation (GHSA-ff6c-w6qf-7xqc); pinned to 1.x to avoid 3.x breakage
     gem 'feedjira'
     gem 'httparty', '>= 0.24.0'  # SSRF vulnerability fix
     gem 'observer'       # used by jekyll-scholar

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,8 +22,8 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
     bibtex-ruby (6.1.0)
       latex-decode (~> 0.0)
@@ -57,7 +57,7 @@ GEM
       time (< 1.0)
     csl-styles (2.0.1)
       csl (~> 2.0)
-    css_parser (1.21.1)
+    css_parser (1.22.0)
       addressable
     cssminify2 (2.0.1)
     csv (3.3.5)
@@ -205,21 +205,21 @@ GEM
       bigdecimal (>= 3.1, < 5)
     namae (1.2.0)
       racc (~> 1.7)
-    nokogiri (1.19.1-aarch64-linux-gnu)
+    nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.1-aarch64-linux-musl)
+    nokogiri (1.19.3-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.1-arm-linux-gnu)
+    nokogiri (1.19.3-arm-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.1-arm-linux-musl)
+    nokogiri (1.19.3-arm-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.1-arm64-darwin)
+    nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.1-x86_64-darwin)
+    nokogiri (1.19.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.1-x86_64-linux-gnu)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.1-x86_64-linux-musl)
+    nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
     observer (0.1.2)
     open-uri (0.5.0)
@@ -230,7 +230,7 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     prism (1.9.0)
-    public_suffix (6.0.2)
+    public_suffix (7.0.5)
     racc (1.8.1)
     rake (13.2.1)
     rb-fsevent (0.11.2)
@@ -291,7 +291,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport (>= 8.0.4.1)
   classifier-reborn
-  css_parser
+  css_parser (~> 1.22)
   feedjira
   httparty (>= 0.24.0)
   jekyll
@@ -312,11 +312,11 @@ DEPENDENCIES
   jekyll-toc
   jekyll-twitter-plugin
   jemoji
-  nokogiri (>= 1.19.1)
+  nokogiri (>= 1.19.3)
   observer
   ostruct
   rexml (>= 3.4.2)
   uri (>= 1.0.4)
 
 BUNDLED WITH
-   2.5.16
+   2.6.9


### PR DESCRIPTION
Resolves all **4 open Dependabot alerts** — all RubyGems transitive deps in `Gemfile.lock`. No application code changes; lockfile bumps only, respecting existing Gemfile constraints.

## Alerts fixed

| # | Severity | Gem | Bump | Advisory |
|---|----------|-----|------|----------|
| 11 | **High** | nokogiri | 1.19.1 → 1.19.3 | CSS selector tokenizer ReDoS (GHSA-c4rq-3m3g-8wgx) |
| 10 | **High** | addressable | 2.8.7 → 2.9.0 | URI template ReDoS (CVE-2026-35611) |
| 12 | Medium | nokogiri | 1.19.1 → 1.19.3 | XSLT transform memory leak (GHSA-v2fc-qm4h-8hqv) |
| 13 | Medium | css_parser | 1.21.1 → 1.22.0 | HTTPS MITM via `VERIFY_NONE` (GHSA-ff6c-w6qf-7xqc) |

`public_suffix` 6.0.2 → 7.0.5 is pulled in as a required dependency of addressable 2.9.0.

## Notes
- **css_parser** pinned to `~> 1.22` to stay on the 1.x line and avoid the 3.x major bump (potential breakage). Our only usage — `load_string!` in `_plugins/download-3rd-party.rb` — is unaffected by the 1.22 change, which only touches remote `load_uri!` HTTPS handling.
- **nokogiri** Gemfile constraint tightened to `>= 1.19.3` to document the security floor.

## Verification
Clean production Jekyll build in the project's Docker container (`done in 232.7s`, exit 0). Remaining build output is pre-existing SASS deprecation / empty-slug warnings unrelated to these bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)