### PR TITLE
Rebrand blog: Ground Truth

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -86,8 +86,8 @@ bing_site_verification: # out your bing-site-verification ID (Bing Webmaster)
 # Blog
 # -----------------------------------------------------------------------------
 
-blog_name: Fred's Data blog # blog_name will be displayed in your blog page
-blog_description: Interesting things I've learned on my data science journey.
+blog_name: Ground Truth # blog_name will be displayed in your blog page
+blog_description: Working well with AI — by learning from its data.
 permalink: /blog/:year/:title/
 lsi: false # produce an index for related posts
 

--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -2,7 +2,7 @@
 layout: default
 permalink: /blog/
 title: blog
-description: Fred's Data blog - insights and lessons learned on the journey from Earth science to data science.
+description: Ground Truth — working well with AI by learning from its data.
 nav: true
 nav_order: 1
 pagination:


### PR DESCRIPTION
Replaces the placeholder blog branding with the new title/subtitle:

- **Ground Truth**
- _Working well with AI — by learning from its data._

## Changes
- `_config.yml` — `blog_name` and `blog_description`
- `_pages/blog.md` — matching SEO/social meta `description`

Title and subtitle were chosen to tie together the Earth-science → ML arc ("ground truth" is a term native to both geoscience and machine learning) and the evidence-driven, human–AI-fluency focus of recent work (CodeFluent, AgentFluent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)